### PR TITLE
Fixing unnecessary creation go client bug

### DIFF
--- a/CS6203/src/group-project/Evaluation/MeasuringDataReplication.go
+++ b/CS6203/src/group-project/Evaluation/MeasuringDataReplication.go
@@ -35,12 +35,12 @@ func main() {
 		glog.Error(err)
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(pollTimeOutMs) * time.Millisecond)
+		client := pb.NewPutKeyServiceClient(conn)
 		defer conn.Close(); defer cancel()
 
 		for key := 0; key < attempts; key++ {
 			glog.Infof(fmt.Sprintf("Attempting put key request - key: %d, val: %d", key, key))
 			startTime := time.Now()
-			client := pb.NewPutKeyServiceClient(conn)
 			if resp, err := client.PutKey(ctx, &pb.PutKeyMsg{Key: strconv.Itoa(key),
 				Val: []byte(strconv.Itoa(key))}); err != nil {
 				panic(err)

--- a/CS6203/src/group-project/Evaluation/PutAndGetKeyTest.go
+++ b/CS6203/src/group-project/Evaluation/PutAndGetKeyTest.go
@@ -37,11 +37,11 @@ func main() {
 		glog.Error(err)
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(pollTimeOutMs) * time.Millisecond)
+		client := pb.NewPutKeyServiceClient(conn)
 		defer conn.Close(); defer cancel()
 
 		for key := 0; key < attempts; key++ {
 			glog.Infof(fmt.Sprintf("Attempting put key request - key: %d, val: %d", key, key))
-			client := pb.NewPutKeyServiceClient(conn)
 			if resp, err := client.PutKey(ctx, &pb.PutKeyMsg{Key: strconv.Itoa(key),
 				Val: []byte(strconv.Itoa(key))}); err != nil {
 				panic(err)
@@ -55,10 +55,10 @@ func main() {
 		glog.Error(err)
 	} else {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(pollTimeOutMs) * time.Millisecond)
+		client := pb.NewGetKeyServiceClient(conn)
 		defer conn.Close(); defer cancel()
 
 		for key := 0; key < attempts; key++ {
-			client := pb.NewGetKeyServiceClient(conn)
 			if resp, err := client.GetKey(ctx, &pb.GetKeyMsg{Key: strconv.Itoa(key)}); err != nil {
 				panic(err)
 			} else if resp.Ack != true {


### PR DESCRIPTION
- Do not create the client in the loop
- Instead, create it before calling multiple puts for keys